### PR TITLE
Torna legendas de períodos clicáveis

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,54 +34,11 @@
 			<a id="tema" class="option transition"></a>
 
 			<div class="course-name" style="display: flex; align-content: center;">
-		
-			
 				<div id="legendas" style="margin-bottom: 5em;" class="periodo-box">
 					<span>Legendas</span>
 				</div>
-				<div id="concluido" style="margin-left: 2em; margin-bottom: 5em;" class="periodo-box baseLegendas">
-					<span>Concluído</span>
-				</div>
-				<div id="p2023-2" class="periodo-box baseLegendas">
-				<span>2025.1</span>
-			   </div>
-				<div id="p2024-1" class="periodo-box baseLegendas">
-				<span>2025.2</span>
-			   </div>
-				<div id="p2024-2" class="periodo-box baseLegendas">
-				<span>2026.1</span>
-			   </div>
-				<div id="p2025-1" class="periodo-box baseLegendas">
-				<span>2026.2</span>
-			   </div>
-				<div id="p2025-2" class="periodo-box baseLegendas">
-				<span>2027.1</span>
-			   </div>
-			   <div id="p2026-1" class="periodo-box baseLegendas">
-				<span>2027.2</span>
-			   </div>
-			   <div id="p2026-2" class="periodo-box baseLegendas">
-				<span>2028.1</span>
-			   </div>
-			   <div id="p2027-1" class="periodo-box baseLegendas">
-				<span>2028.2</span>
-			   </div>
-			   <div id="p2027-2" class="periodo-box baseLegendas">
-				<span>2029.1</span>
-			   </div>
-			   <div id="p2028-1" class="periodo-box baseLegendas">
-				<span>2029.2</span>
-			   </div>
-			   <div id="p2028-2" class="periodo-box baseLegendas">
-				<span>2030.1</span>
-			   </div>
-			   <div id="p2029-1" class="periodo-box baseLegendas">
-				<span>2030.2</span>
-			   </div>
 			</div>
 		</div>
-			
-	
 
 	</body>
 </html>

--- a/js/database.js
+++ b/js/database.js
@@ -5,7 +5,7 @@ window.semesters = 9;
 /* The first color is default for selecting options as well, so make sure to choose that one wisely */
 window.colors = ["#83f28e", "#eca0df", "#6a9eda","#F0C929", "#44e6e0","#c75062", "#3f8880", "#fbaa74", "#E48586", "#916DB3", "#404d83", "#fbdb74", "#747372"];
 
-window.legendas = ["Concluído", "2023.1", "2023.2", "2024.1", "2024.2", "2025.1", "2025.2","2026.1", "2026.2", "2027.1", "2027.2", "2028.1", "2028.2", "2029.1"];
+window.currentSemester = [2025, 1]
 
 // Order of courses matters: do not swap positions. Append at the end.
 window.courses = [

--- a/js/index.js
+++ b/js/index.js
@@ -18,6 +18,8 @@ var pressAndHoldTime = 500;    		// Period of time for the program to consider a
 	 // Handles mobile orientation warnings:
 	 handleMobileOrientation();
 
+     createSemesterButtons();
+
      // Adds click event to close all tooltips:
      $("body").click(function(e) {
 
@@ -640,6 +642,54 @@ function handleMobileOrientation(){
 	});
 }
 
+function createSemesterButton(semester, order){
+    // Turns [2025, 1] into "2025.1", for example
+    let semesterString = `${semester[0]}.${semester[1]}`;
+
+    let newButton = $("<div>").addClass("periodo-box baseLegendas");
+    newButton.css("background-color", window.colors[order]);
+    
+    let buttonText = (order == 0) ? "Concluído" : semesterString;
+    let innerSpan = $(`<span>${buttonText}</span>`);
+
+    newButton.append(innerSpan);
+
+    let mouseDown = (document.ontouchstart === null) ? "touchstart" : "mousedown";
+    newButton.on(mouseDown, () => {
+        let bucketButton = $("#bucket");
+        colorId = order;
+		bucketButton.css("background-color", window.colors[colorId]);
+
+		setCookie("colorId", colorId.toString());
+	});
+
+    return newButton;
+}
+
+function nextSemester(semester){
+    if (semester[1] == 2) {
+        semester[0]++;
+        semester[1] = 1;
+    }
+    else {
+        semester[1] = 2;
+    }
+
+    return semester
+}
+
+function createSemesterButtons(){
+    let currentSemester = window.currentSemester;
+    let container = $(".course-name");
+
+    for (let i = 0; i < window.colors.length; i++) {
+        let semesterButton = createSemesterButton(currentSemester, i);
+        container.append(semesterButton);
+
+        currentSemester = nextSemester(currentSemester);
+    }
+}
+
 //////////////////////////////////
 /// HANDLE HEX COLOR DARKENING ///
 //////////////////////////////////
@@ -740,8 +790,4 @@ function setCookie(cname, cvalue) {
     d.setTime(d.getTime() + (20 * 365 * 24 * 60 * 60 * 1000));
     var expires = "expires="+d.toUTCString();
     document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
-}
-
-function adicionarLegendas() {
-    document.appendChild($("#legendas").append(window.legendas));
 }

--- a/static/index.css
+++ b/static/index.css
@@ -246,45 +246,6 @@ body {
     font-family: Rounded;
 }
 
-#p2023-2 {
-    background-color: #eca0df;
-}
-#p2024-1 {
-    background-color: #6a9eda;
-}
-#p2024-2 {
-    background-color: #F0C929;
-}
-#p2025-1 {
-    background-color: #44e6e0;
-}
-#p2025-2 {
-    background-color: #b82f44;
-}
-#p2026-1 {
-    background-color: #3f8880;
-}
-
-#p2026-2 {
-    background-color: #fbaa74;
-}
-#p2027-1 {
-    background-color: #E48586;
-}
-
-#p2027-2 {
-    background-color: #916DB3;
-}
-#p2028-1 {
-    background-color: #404d83;
-}
-
-#p2028-2 {
-    background-color: #fbdb74;
-}
-#p2029-1 {
-    background-color: #747372;
-}
 #concluido {
     background-color: #83f28e;
 }


### PR DESCRIPTION
Oi! Eu uso esse site sempre, e sentia falta dessa feature a muito tempo, então tá aí:

Hoje o único jeito de o usuário trocar a cor que quer preencher é clicando no ícone de balde, que itera em ciclo pelas cores. O problema é que se o usuário acidentalmente passar direto pela cor que queria, ele precisa clicar mais de 10 vezes no balde pra voltar até ela 😭.

Para resolver isso, tornei os botões de legenda no canto inferior clicáveis. O usuário pode clicar no período que quer colorir, e o balde vai mudar para essa cor. Aproveitei para fazer com que essas legendas sejam geradas dinamicamente, facilitando a atualização a cada período. Agora, se mudar o window.currentSemester em `js/database.js`, todas as legendas vão se ajustar automaticamente.
